### PR TITLE
add support for JavaScript

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -1,16 +1,23 @@
 [
     // TODO: figure out how to match multiple scopes.
     { "keys": ["super+option+a"], "command": "clang_format",
-        "context":  
+        "context":
         [
             {"key": "selector", "operator": "equal", "operand": "source.c++"}
         ],
     },
 
     { "keys": ["super+option+a"], "command": "clang_format",
-    "context":  
-    [
-        {"key": "selector", "operator": "equal", "operand": "source.c"}
-    ],
-}
+        "context":
+        [
+           {"key": "selector", "operator": "equal", "operand": "source.c"}
+        ],
+    },
+
+    { "keys": ["super+option+a"], "command": "clang_format",
+        "context":
+        [
+            {"key": "selector", "operator": "equal", "operand": "source.js"}
+        ]
+    }
 ]


### PR DESCRIPTION
This commit looks bigger than it actually is because I have Sublime set to remove trailing whitespace. Sorry 'bout that. It's really a single key added to the sublime-keymap file. It's identical to the other ones ("super+option+a"), except that the operand is "source.js". I added a single three-line function to clang_format.py called is_supported(), that compares the current syntax with 'C.tmLanguage', 'C++.tmLanguage', and 'JavaScript.tmLanguage'. A three-line function and a single key in the keymap is all it took to support JavaScript. I think adding JS support will increase the popularity of your plugin, when more people discover that clang-format works on JS files.
