### PR TITLE
Fix is_supported for Sublime Text 3 Build 3093 and up

### DIFF
--- a/clang_format.py
+++ b/clang_format.py
@@ -139,7 +139,7 @@ def load_settings():
 def is_supported(lang):
     # TODO: Add Objective-C and Objective-C++ here.
     supported = ('C', 'C++', 'C++11', 'JavaScript')
-    return any((lang.endswith(l + '.tmLanguage') for l in supported))
+    return any((lang.endswith((l + '.tmLanguage', l + '.sublime-syntax')) for l in supported))
 
 # Triggered when the user runs clang format.
 class ClangFormatCommand(sublime_plugin.TextCommand):


### PR DESCRIPTION
Sublime Text 3 Build 3093 and above changes the file extension to .sublime-syntax for syntax files.  This is a quick fix that supports both the new extension and older one for previous versions of Sublime Text.