### PR TITLE
Fix for issue #23

### DIFF
--- a/clang_format.py
+++ b/clang_format.py
@@ -40,6 +40,45 @@ all_settings  = [
     "SpacesInParentheses", "SpacesInSquareBrackets", "Standard", "TabWidth", "UseTab"
 ]
 
+st_encodings_trans = {
+   "UTF-8" : "utf-8",
+   "UTF-8 with BOM" : "utf-8-sig",
+   "UTF-16 LE" : "utf-16-le",
+   "UTF-16 LE with BOM" : "utf-16",
+   "UTF-16 BE" : "utf-16-be",
+   "UTF-16 BE with BOM" : "utf-16",
+   "Western (Windows 1252)" : "cp1252",
+   "Western (ISO 8859-1)" : "iso8859-1",
+   "Western (ISO 8859-3)" : "iso8859-3",
+   "Western (ISO 8859-15)" : "iso8859-15",
+   "Western (Mac Roman)" : "mac-roman",
+   "DOS (CP 437)" : "cp437",
+   "Arabic (Windows 1256)" : "cp1256",
+   "Arabic (ISO 8859-6)" : "iso8859-6",
+   "Baltic (Windows 1257)" : "cp1257",
+   "Baltic (ISO 8859-4)" : "iso8859-4",
+   "Celtic (ISO 8859-14)" : "iso8859-14",
+   "Central European (Windows 1250)" : "cp1250",
+   "Central European (ISO 8859-2)" : "iso8859-2",
+   "Cyrillic (Windows 1251)" : "cp1251",
+   "Cyrillic (Windows 866)" : "cp866",
+   "Cyrillic (ISO 8859-5)" : "iso8859-5",
+   "Cyrillic (KOI8-R)" : "koi8-r",
+   "Cyrillic (KOI8-U)" : "koi8-u",
+   "Estonian (ISO 8859-13)" : "iso8859-13",
+   "Greek (Windows 1253)" : "cp1253",
+   "Greek (ISO 8859-7)" : "iso8859-7",
+   "Hebrew (Windows 1255)" : "cp1255",
+   "Hebrew (ISO 8859-8)" : "iso8859-8",
+   "Nordic (ISO 8859-10)" : "iso8859-10",
+   "Romanian (ISO 8859-16)" : "iso8859-16",
+   "Turkish (Windows 1254)" : "cp1254",
+   "Turkish (ISO 8859-9)" : "iso8859-9",
+   "Vietnamese (Windows 1258)" :  "cp1258",
+   "Hexadecimal" : None,
+   "Undefined" : None
+}
+
 # Check if we are running on a Windows operating system
 os_is_windows = os.name == 'nt'
 
@@ -164,8 +203,8 @@ class ClangFormatCommand(sublime_plugin.TextCommand):
         # The below code has been taken and tweaked from llvm.
         #----------------------------------------------------------------------#
 
-        encoding = self.view.encoding()
-        if encoding == 'Undefined':
+        encoding = st_encodings_trans[self.view.encoding()]
+        if encoding is None:
             encoding = 'utf-8'
 
         # We use 'file' not 'File' when passing to the binary.


### PR DESCRIPTION
I added a manual translation between the string returned by view.encoding() and the encoding strings expected by buf.encode