### PR TITLE
Faulty Comma in OS X Keymap

### DIFF
--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -4,14 +4,14 @@
         "context":
         [
             {"key": "selector", "operator": "equal", "operand": "source.c++"}
-        ],
+        ]
     },
 
     { "keys": ["super+option+a"], "command": "clang_format",
         "context":
         [
             {"key": "selector", "operator": "equal", "operand": "source.c"}
-        ],
+        ]
     },
 
     { "keys": ["super+option+a"], "command": "clang_format",


### PR DESCRIPTION
Trailing comma in the OS X keymap file was causing a settings parse error. This PR fixes it.