### PR TITLE
support per-project settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,21 @@ Use
   http://clang.llvm.org/docs/ClangFormatStyleOptions.html.
 - Settings for the 'Custom' format and others are available through the Sublime
   Text preferences.
-- It is possible to enable the formatter on every
-  save to a C/C++ file. To change settings on a per-package basis, check out the
-  package "Project-Specific".
+- It is possible to run the formatter on every save to a file, change settings
+  to `"format_on_save": true`.
+- To change settings on a per-package basis, add them under `ClangFormat` key,
+  example project.sublime-settings:
+
+  ```json
+{
+  "folders": [],
+  "settings": {
+    "ClangFormat": {
+      "format_on_save": true
+    }
+  }
+}
+```
 
 
 If You Liked This

--- a/clang_format.py
+++ b/clang_format.py
@@ -175,12 +175,14 @@ def load_settings():
     global style
     global format_on_save
     global languages
-    settings = sublime.load_settings(settings_file)
+    settings_global = sublime.load_settings(settings_file)
+    settings_local = sublime.active_window().active_view().settings().get('ClangFormat', {})
+    load = lambda name, default: settings_local.get(name, settings_global.get(name, default))
     # Load settings, with defaults.
-    binary         = settings.get('binary', default_binary)
-    style          = settings.get('style',   styles[0]    )
-    format_on_save = settings.get('format_on_save', False  )
-    languages      = settings.get('languages', ['C', 'C++', 'C++11', 'JavaScript'])
+    binary         = load('binary', default_binary)
+    style          = load('style', styles[0])
+    format_on_save = load('format_on_save', False)
+    languages      = load('languages', ['C', 'C++', 'C++11', 'JavaScript'])
 
 def is_supported(lang):
     load_settings()


### PR DESCRIPTION
usage: project.sublime-settings
```json
{
  "folders": [],
  "settings": {
    "ClangFormat": {
      "format_on_save": true
    }
  }
}
```

Modified readme to reflect:
- `ProjectSpecific` is not needed anymore (it didn't install/work on Sublime 3 anyway)
- format_on_save is a separate feature from projectspecific
- format_on_save is not bound to C/C++, e.g. it work just as well with Javascript