### PR TITLE
Full support for custom brace wrapping

### DIFF
--- a/clang_format.py
+++ b/clang_format.py
@@ -129,6 +129,8 @@ def dic_to_yaml_simple(d):
         output += ": "
         if type(d[k]) is bool:
             output += str(d[k]).lower()
+        elif type(d[k]) is dict:
+            output += "{" + dic_to_yaml_simple(d[k]) + "}"
         else:
             output += str(d[k])
         n -= 1

--- a/clang_format_custom.sublime-settings
+++ b/clang_format_custom.sublime-settings
@@ -134,7 +134,25 @@
     // bool BeforeCatch Wrap before catch.
     // bool BeforeElse Wrap before else.
     // bool IndentBraces Indent the wrapped braces themselves.
-// "BraceWrapping": "IndentBraces",
+    // bool SplitEmptyFunction If false, empty function body can be put on a single line.
+    // bool SplitEmptyRecord If false, empty record (e.g. class, struct or union) body can be put on a single line.
+    // bool SplitEmptyNamespace If false, empty namespace body can be put on a single line.
+    "BraceWrapping":{
+//        "AfterClass":             false,
+//        "AfterControlStatement":  false,
+//        "AfterEnum":              false,
+//        "AfterFunction":          false,
+//        "AfterNamespace":         false,
+//        "AfterObjCDeclaration":   false,
+//        "AfterStruct":            false,
+//        "AfterUnion":             false,
+//        "BeforeCatch":            false,
+//        "BeforeElse":             false,
+//        "IndentBraces":           false,
+//        "SplitEmptyFunction:"     true,
+//        "SplitEmptyRecord":       true,
+//        "SplitEmptyNamespace":    true
+    },
 
     // Break after each annotation on a field in Java files.
 // "BreakAfterJavaFieldAnnotations": true,


### PR DESCRIPTION
Grants access to all the Brace Wrapping flags previously hidden due to non recursive dictionary yaml values. Also adds the Brace Wrapping parameters to the custom settings file. There is no verification of the sub keys for BraceWrapping like there is with all other settings, so should a user select an invalid BraceWrapping key, clang-format will throw an error, but its diagnostics will be clear to the user why the error has happened.

This is mean't to be a more in depth fix than #43 as it updates the setting file too