### PR TITLE
Fixed removing tabs in non-formatted code

### DIFF
--- a/clang_format.py
+++ b/clang_format.py
@@ -285,9 +285,18 @@ class ClangFormatCommand(sublime_plugin.TextCommand):
             return
 
         # If there were no errors, we replace the view with the outputted buf.
+        # Temporarily disable tabs to space so that tabs elsewhere in the file
+        # do not get modified if they were not part of the formatted selection
+        prev_tabs_to_spaces = self.view.settings().get('translate_tabs_to_spaces')
+        self.view.settings().set('translate_tabs_to_spaces', False)
+
         self.view.replace(
             edit, sublime.Region(0, self.view.size()),
             output.decode(encoding))
+
+        # Re-enable previous tabs to space setting
+        self.view.settings().set('translate_tabs_to_spaces', prev_tabs_to_spaces)
+
 
         # TODO: better semantics for re-positioning cursors!
 


### PR DESCRIPTION
When using the translate_tabs_to_spaces settings, all
of the tabs of a file would be translated to spaces
even if they were not part of the formatted code. This
could be annoying with bigger file containing both spaces
and tabs for formatting.

The issue comes from the fact that we overwrite all of the
file even when formatting  selected text. Therefore Sublime
would translate the copied tabs to spaces even when not part
of the formatted code.

To fix this, we simply temporarily disable the
translate_tabs_to_spaces setting and set it back once the code
has been copied.