### PR TITLE
Change default value "PAS_Left" to "Left"

### DIFF
--- a/clang_format_custom.sublime-settings
+++ b/clang_format_custom.sublime-settings
@@ -344,7 +344,7 @@
     //     PAS_Left   (in configuration: Left) Align pointer to the left.
     //     PAS_Right  (in configuration: Right) Align pointer to the right.
     //     PAS_Middle (in configuration: Middle) Align pointer in the middle.
-//  "PointerAlignment": "PAS_Left",
+//  "PointerAlignment": "Left",
 
     // If true, a space may be inserted after C style casts.
 // "SpaceAfterCStyleCast": true,


### PR DESCRIPTION
If I set my PointerAlignment setting to "PAS_Left" (uncomment the setting line)
The following error occurs upon formatting:
```
Error parsing-style: Invalid argument
```

The comment in the settings file cites probably [clang](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) which also says that in config the "PAS_" prefix is omitted.

In my version (v1.3.6 ) on Ubuntu `Left`, `Middle`, and `Right` do the work.