### PR TITLE
New clang formatting shortcut

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -19,5 +19,12 @@
         [
             {"key": "selector", "operator": "equal", "operand": "source.js"}
         ]
+    },
+    
+    // To run the clang formatter on the whole file without changing the 
+    // chosen formatting style.
+    { "keys": ["ctrl+e"], "command": "clang_format",
+        "args": {"whole_buffer": true}
     }
+
 ]

--- a/Default (OSX).sublime-keymap
+++ b/Default (OSX).sublime-keymap
@@ -19,5 +19,11 @@
         [
             {"key": "selector", "operator": "equal", "operand": "source.js"}
         ]
+    },
+
+    // To run the clang formatter on the whole file without changing the 
+    // chosen formatting style.
+    { "keys": ["super+e"], "command": "clang_format",
+        "args": {"whole_buffer": true}
     }
 ]

--- a/Default (Windows).sublime-keymap
+++ b/Default (Windows).sublime-keymap
@@ -19,5 +19,10 @@
         [
             {"key": "selector", "operator": "equal", "operand": "source.js"}
         ]
+    },
+
+    // To run the clang formatter on the whole file in one shortcut.
+    { "keys": ["ctrl+e"], "command": "clang_format",
+        "args": {"whole_buffer": "True"}
     }
 ]

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Use
   Text preferences.
 - It is possible to run the formatter on every save to a file, change settings
   to `"format_on_save": true`.
-- To change settings on a per-package basis, add them under `ClangFormat` key,
-  example project.sublime-settings:
 - To run the formatter in one stroke, press `ctrl+e` for windows and linux
   or `super+e` for OSX. You can always change the keybinding in the
   keymap to your liking.
+- To change settings on a per-package basis, add them under `ClangFormat` key,
+  example project.sublime-settings:
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Use
   example project.sublime-settings:
 - To run the formatter in one stroke, press `ctrl+e` for windows and linux
   or `super+e` for OSX. You can always change the keybinding in the
-  keymap to your likings.
+  keymap to your liking.
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Use
   to `"format_on_save": true`.
 - To change settings on a per-package basis, add them under `ClangFormat` key,
   example project.sublime-settings:
+- To run the formatter in one stroke, press `ctrl+e` for windows and linux
+  or `super+e` for OSX. You can always change the keybinding in the
+  keymap to your likings.
 
 ```json
 {


### PR DESCRIPTION
Created a new shortcut to run the clang formatter on the whole file in one go. It's just a little more efficient then the menus.