### PR TITLE
add option to pass --fallback-style to clang-format

### DIFF
--- a/clang_format.py
+++ b/clang_format.py
@@ -186,6 +186,7 @@ def load_settings():
     # We set these globals.
     global binary
     global style
+    global fallback_style
     global format_on_save
     global languages
     settings_global = sublime.load_settings(settings_file)
@@ -194,6 +195,7 @@ def load_settings():
     # Load settings, with defaults.
     binary         = load('binary', default_binary)
     style          = load('style', styles[0])
+    fallback_style = load('fallback_style', None)
     format_on_save = load('format_on_save', False)
     languages      = load('languages', ['C', 'C++', 'C++11', 'JavaScript'])
 
@@ -230,6 +232,9 @@ class ClangFormatCommand(sublime_plugin.TextCommand):
             command = [binary, load_custom()]
         else:
             command = [binary, '-style', _style]
+
+        if fallback_style:
+            command.extend(['-fallback-style', fallback_style])
 
         regions = []
         if whole_buffer:

--- a/clang_format.sublime-settings
+++ b/clang_format.sublime-settings
@@ -17,6 +17,11 @@
 
     "style": "Google",
 
+    // If style is set to 'File', but not '.clang-format' file is found, this style
+    // is used instead. Use 'none' to skip formatting in this case.
+
+    "fallback_style": "Google",
+
     // Setting this to true will run the formatter on every save. If you want to
     // only enable this for a given project, try checking out the package
     // "Project-Specific".


### PR DESCRIPTION
The '--fallback-style' option can be used to tell clang-format what to do in case '--style=File' is specified, but no '.clang-format' file is found.

This closes #70